### PR TITLE
Directly use LuaTeX \mathstyle primitive

### DIFF
--- a/mathstyle.dtx
+++ b/mathstyle.dtx
@@ -129,7 +129,7 @@ and the derived files
 %<package>\NeedsTeXFormat{LaTeX2e}
 %<package>\ProvidesPackage{mathstyle}
 %<*package|driver>
-  [2014/06/10 v0.90a Tracking mathstyle implicitly]
+  [2015/07/17 v0.90b Tracking mathstyle implicitly]
 %</package|driver>
 %<*driver>
 \documentclass{ltxdoc}

--- a/mathstyle.dtx
+++ b/mathstyle.dtx
@@ -4,6 +4,7 @@
 % Copyright (C) 2007-2008 by Morten Hoegholm
 % Copyright (C) 2007-2014 by Lars Madsen
 % Copyright (C) 2007-2014 by Will Robertson
+% Copyright (C) 2015 by Will Robertson, Joseph Wright
 %
 % This work may be distributed and/or modified under the
 % conditions of the LaTeX Project Public License, either
@@ -78,6 +79,7 @@ Copyright (C) 1997-2003 by Michael J. Downes
 Copyright (C) 2007-2011 by Morten Hoegholm et al
 Copyright (C) 2007-2014 by Lars Madsen
 Copyright (C) 2007-2014 by Will Robertson
+Copyright (C) 2015 by Will Robertson, Joseph Wright
 
 This work may be distributed and/or modified under the
 conditions of the LaTeX Project Public License, either

--- a/mathstyle.dtx
+++ b/mathstyle.dtx
@@ -282,19 +282,32 @@ and the derived files
 % We need to keep track of whether we're in inline or display maths, and the only
 % way to do that is to add a switch inside \verb|\everydisplay|.
 % We act sensibly and preserve any of the previous contents of that token register
-% before adding our own code here.
+% before adding our own code here. As we'll see in a second, Lua\TeX{}
+% provides a native mechanism for this so we don't need any action in that
+% case. (Various other parts of the code also need to have different paths
+% for Lua\TeX{} use.)
 %    \begin{macrocode}
-\everydisplay=\expandafter{\the\everydisplay\chardef\mathstyle\z@}
+\begingroup\expandafter\expandafter\expandafter\endgroup
+\expandafter\ifx\csname directlua\endcsname\relax
+  \everydisplay=\expandafter{\the\everydisplay\chardef\mathstyle\z@}
+\fi
 %    \end{macrocode}
 % \end{macro}
 %
 % \begin{macro}{\mathstyle}
-% A counter for the math style: 0--display, 1--text, 2--script, 3--scriptscript.
+% A counter for the math style: 0--display, 2--text, 4--script, 6--scriptscript.
 % The logic is that display maths will explicitly
 % set \verb|\mathstyle| to zero (see above), so by default it is set to the
-% `text' maths style.
+% `text' maths style.  With Lua\TeX{} there is a primitive to do the same
+% so it just has to be enabled. Note that in all cases we use Lua\TeX{}-like
+% numbering for the states. 
 %    \begin{macrocode}
-\chardef\mathstyle\@ne
+\begingroup\expandafter\expandafter\expandafter\endgroup
+\expandafter\ifx\csname directlua\endcsname\relax
+  \chardef\mathstyle\@ne
+\else
+  \directlua{tex.enableprimitives("", {"mathstyle"})}
+\fi
 %    \end{macrocode}
 % \end{macro}
 %
@@ -313,16 +326,20 @@ and the derived files
 \@saveprimitive\atopwithdelims\@@atopwithdelims
 \@saveprimitive\abovewithdelims\@@abovewithdelims
 %    \end{macrocode}
-% Then we redeclare the four style changing primitives.
+% Then we redeclare the four style changing primitives: set the value of
+% \cs{mathstyle} if Lua\TeX{} is not in use.q
 %    \begin{macrocode}
-\DeclareRobustCommand{\displaystyle}{%
-  \@@displaystyle \chardef\mathstyle\z@}
-\DeclareRobustCommand{\textstyle}{%
-  \@@textstyle \chardef\mathstyle\@ne}
-\DeclareRobustCommand{\scriptstyle}{%
-  \@@scriptstyle \chardef\mathstyle\tw@}
-\DeclareRobustCommand{\scriptscriptstyle}{%
-  \@@scriptscriptstyle \chardef\mathstyle\thr@@}
+\begingroup\expandafter\expandafter\expandafter\endgroup
+\expandafter\ifx\csname directlua\endcsname\relax
+  \DeclareRobustCommand{\displaystyle}{%
+    \@@displaystyle \chardef\mathstyle\z@}
+  \DeclareRobustCommand{\textstyle}{%
+    \@@textstyle \chardef\mathstyle\tw@}
+  \DeclareRobustCommand{\scriptstyle}{%
+    \@@scriptstyle \chardef\mathstyle4 }
+  \DeclareRobustCommand{\scriptscriptstyle}{%
+    \@@scriptscriptstyle \chardef\mathstyle6 }
+\fi
 %    \end{macrocode}
 % First we get the primitive operations. These should have been
 % control sequences in \TeX\ just like operations for begin math, end
@@ -339,13 +356,20 @@ and the derived files
 %    \end{macrocode}
 % If we enter a sub- or superscript the \cs{mathstyle} must be
 % adjusted. Since all is happening in a group, we do not have to worry
-% about resetting.
+% about resetting. We can't tell the difference between cramped and
+% non-cramped styles unless Lua\TeX{} is in use, in which case this command
+% is a no-op.
 %    \begin{macrocode}
-\def\subsupstyle{%
-  \ifnum\mathstyle<\tw@ \chardef\mathstyle\tw@
-  \else \chardef\mathstyle\thr@@   
-  \fi
-}
+\begingroup\expandafter\expandafter\expandafter\endgroup
+\expandafter\ifx\csname directlua\endcsname\relax
+  \def\subsupstyle{%
+    \ifnum\mathstyle<5 \chardef\mathstyle4 %
+    \else \chardef\mathstyle6 %
+    \fi
+  }
+\else
+  \def\subsupstyle{}
+\fi
 %    \end{macrocode}
 % Provide commands with meaningful names for the two primitives, cf.\
 % \cs{mathrel}.
@@ -366,13 +390,19 @@ and the derived files
 %    \begin{macrocode}
 \def\mathchoice{%
   \relax\ifcase\mathstyle
-    \expandafter\@firstoffour
+    \expandafter\@firstoffour % Display
   \or
-    \expandafter\@secondoffour
+    \expandafter\@firstoffour % Cramped display
   \or
-    \expandafter\@thirdoffour
+    \expandafter\@secondoffour % Text
+  \or
+    \expandafter\@secondoffour % Cramped text
+  \or
+    \expandafter\@thirdoffour % Script
+  \or
+    \expandafter\@thirdoffour % Cramped script
   \else
-    \expandafter\@fourthoffour
+    \expandafter\@fourthoffour % (Cramped) Scriptscript
   \fi
 }
 %    \end{macrocode}
@@ -418,14 +448,24 @@ and the derived files
 % The \cs{fracstyle} command is a switch to go one level down but no
 % further than three.
 %    \begin{macrocode}
-\def\fracstyle{\ifcase\mathstyle
-    \chardef\mathstyle=\@ne
-  \or 
-    \chardef\mathstyle=\tw@
-  \else 
-    \chardef\mathstyle=\thr@@
-  \fi
-}
+\begingroup\expandafter\expandafter\expandafter\endgroup
+\expandafter\ifx\csname directlua\endcsname\relax
+  \def\fracstyle{%
+    \ifcase\mathstyle
+      \chardef\mathstyle=\@ne
+    \or
+      \chardef\mathstyle=\@ne
+    \or 
+      \chardef\mathstyle=\tw@
+    \or 
+      \chardef\mathstyle=\tw@
+    \else 
+      \chardef\mathstyle=\thr@@
+    \fi
+  }
+\else
+  \def\fracstyle{}
+\fi
 %    \end{macrocode}
 % The \cs{currentmathstyle} checks the value of \cs{mathstyle} and
 % switches to it so it is in essence the opposite of \cs{displaystyle}
@@ -435,10 +475,16 @@ and the derived files
   \ifcase\mathstyle
     \@@displaystyle
   \or
+    \@@displaystyle
+  \or
+    \@@textstyle
+  \or
     \@@textstyle
   \or
     \@@scriptstyle
   \or
+    \@@scriptstyle
+  \else
     \@@scriptscriptstyle
   \fi}
 %    \end{macrocode}

--- a/testfiles/00-test-1.tlg
+++ b/testfiles/00-test-1.tlg
@@ -30,14 +30,14 @@ Completed box being shipped out [1]
 ...\hbox(0.0+0.0)x307.28978
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(483.69687+0.0)x307.28978, glue set 433.7616fil
+..\vbox(483.69687+0.0)x307.28978, glue set 433.76166fil
 ...\write-{}
 ...\glue(\topskip) 10.0
 ...\rule(0.0+0.0)x*
 ...\penalty 10000
 ...\glue 6.44444
 ...\glue(\baselineskip) 4.5
-...\hbox(7.5+2.5)x307.28978, glue set 294.5119fil
+...\hbox(7.5+2.5)x307.28978, glue set 294.51196fil
 ....\glue 0.0 plus 1.0fil
 ....\hbox(7.5+2.5)x12.77782
 .....\OT1/cmr/m/n/10 (
@@ -204,4 +204,3 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 0.0001fil
 ..\glue(\baselineskip) 30.0
 ..\hbox(0.0+0.0)x307.28978
-{/usr/local/texlive/2014/texmf-var/fonts/map/pdftex/updmap/pdftex.map}

--- a/testfiles/compact.tlg
+++ b/testfiles/compact.tlg
@@ -30,14 +30,14 @@ Completed box being shipped out [1]
 ...\hbox(0.0+0.0)x307.28978
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(483.69687+0.0)x307.28978, glue set 405.7090fil
+..\vbox(483.69687+0.0)x307.28978, glue set 405.70909fil
 ...\write-{}
 ...\glue(\topskip) 10.0
 ...\rule(0.0+0.0)x*
 ...\penalty 10000
 ...\glue 5.47221
 ...\glue(\baselineskip) 4.5
-...\hbox(7.5+2.5)x307.28978, glue set 294.5119fil
+...\hbox(7.5+2.5)x307.28978, glue set 294.51196fil
 ....\glue 0.0 plus 1.0fil
 ....\hbox(7.5+2.5)x12.77782
 .....\OT1/cmr/m/n/10 (
@@ -118,4 +118,3 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 0.0001fil
 ..\glue(\baselineskip) 30.0
 ..\hbox(0.0+0.0)x307.28978
-{/usr/local/texlive/2014/texmf-var/fonts/map/pdftex/updmap/pdftex.map}

--- a/testfiles/compact_w_slash.tlg
+++ b/testfiles/compact_w_slash.tlg
@@ -30,10 +30,10 @@ Completed box being shipped out [1]
 ...\hbox(0.0+0.0)x307.28978
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(483.69687+0.0)x307.28978, glue set 336.5093fil
+..\vbox(483.69687+0.0)x307.28978, glue set 336.50938fil
 ...\write-{}
 ...\glue(\topskip) 3.16669
-...\hbox(6.83331+1.94444)x307.28978, glue set 271.8730fil
+...\hbox(6.83331+1.94444)x307.28978, glue set 271.87305fil
 ....\hbox(0.0+0.0)x15.0
 ....\OT1/cmr/m/n/10 B
 ....\OT1/cmr/m/n/10 u
@@ -79,7 +79,7 @@ Completed box being shipped out [1]
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\baselineskip) 2.55556
-...\hbox(6.94444+0.0)x307.28978, glue set 265.8730fil
+...\hbox(6.94444+0.0)x307.28978, glue set 265.87305fil
 ....\hbox(0.0+0.0)x15.0
 ....\OT1/cmr/m/n/10 W
 ....\kern-0.83334
@@ -142,7 +142,7 @@ Completed box being shipped out [1]
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\baselineskip) 2.55556
-...\hbox(6.94444+0.0)x307.28978, glue set 291.1786fil
+...\hbox(6.94444+0.0)x307.28978, glue set 291.17862fil
 ....\OT1/cmr/m/n/10 a
 ....\OT1/cmr/m/n/10 n
 ....\OT1/cmr/m/n/10 d
@@ -220,4 +220,3 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 0.0001fil
 ..\glue(\baselineskip) 30.0
 ..\hbox(0.0+0.0)x307.28978
-{/usr/local/texlive/2014/texmf-var/fonts/map/pdftex/updmap/pdftex.map}

--- a/testfiles/condition.tlg
+++ b/testfiles/condition.tlg
@@ -30,7 +30,7 @@ Completed box being shipped out [1]
 ...\hbox(0.0+0.0)x307.28978
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(483.69687+0.0)x307.28978, glue set 253.2556fil
+..\vbox(483.69687+0.0)x307.28978, glue set 253.25563fil
 ...\write-{}
 ...\glue(\topskip) 0.0
 ...\hbox(13.20952+6.85951)x307.28978, glue set 1.0
@@ -60,7 +60,7 @@ Completed box being shipped out [1]
 .....\hbox(13.20952+6.85951)x8.11526
 ......\hbox(0.0+0.0)x1.2, shifted -2.5
 ......\vbox(13.20952+6.85951)x5.71527
-.......\hbox(6.44444+0.0)x5.71527, glue set 0.3576fil
+.......\hbox(6.44444+0.0)x5.71527, glue set 0.35764fil
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\OT1/cmr/m/n/10 1
 ........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -133,7 +133,7 @@ Completed box being shipped out [1]
 .....\hbox(13.20952+6.85951)x8.11526
 ......\hbox(0.0+0.0)x1.2, shifted -2.5
 ......\vbox(13.20952+6.85951)x5.71527
-.......\hbox(6.44444+0.0)x5.71527, glue set 0.3576fil
+.......\hbox(6.44444+0.0)x5.71527, glue set 0.35764fil
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\OT1/cmr/m/n/10 1
 ........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -206,7 +206,7 @@ Completed box being shipped out [1]
 .....\hbox(13.20952+6.85951)x8.11526
 ......\hbox(0.0+0.0)x1.2, shifted -2.5
 ......\vbox(13.20952+6.85951)x5.71527
-.......\hbox(6.44444+0.0)x5.71527, glue set 0.3576fil
+.......\hbox(6.44444+0.0)x5.71527, glue set 0.35764fil
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\OT1/cmr/m/n/10 1
 ........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -278,7 +278,7 @@ Completed box being shipped out [1]
 .....\hbox(13.20952+6.85951)x8.11526
 ......\hbox(0.0+0.0)x1.2, shifted -2.5
 ......\vbox(13.20952+6.85951)x5.71527
-.......\hbox(6.44444+0.0)x5.71527, glue set 0.3576fil
+.......\hbox(6.44444+0.0)x5.71527, glue set 0.35764fil
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\OT1/cmr/m/n/10 1
 ........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -347,7 +347,7 @@ Completed box being shipped out [1]
 .....\hbox(13.20952+6.85951)x8.11526
 ......\hbox(0.0+0.0)x1.2, shifted -2.5
 ......\vbox(13.20952+6.85951)x5.71527
-.......\hbox(6.44444+0.0)x5.71527, glue set 0.3576fil
+.......\hbox(6.44444+0.0)x5.71527, glue set 0.35764fil
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\OT1/cmr/m/n/10 1
 ........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -416,7 +416,7 @@ Completed box being shipped out [1]
 .....\hbox(13.20952+6.85951)x8.11526
 ......\hbox(0.0+0.0)x1.2, shifted -2.5
 ......\vbox(13.20952+6.85951)x5.71527
-.......\hbox(6.44444+0.0)x5.71527, glue set 0.3576fil
+.......\hbox(6.44444+0.0)x5.71527, glue set 0.35764fil
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 ........\OT1/cmr/m/n/10 1
 ........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -454,4 +454,3 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 0.0001fil
 ..\glue(\baselineskip) 30.0
 ..\hbox(0.0+0.0)x307.28978
-{/usr/local/texlive/2014/texmf-var/fonts/map/pdftex/updmap/pdftex.map}

--- a/testfiles/dgroup_dmath_star.tlg
+++ b/testfiles/dgroup_dmath_star.tlg
@@ -30,10 +30,10 @@ Completed box being shipped out [1]
 ...\hbox(0.0+0.0)x307.28978
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(483.69687+0.0)x307.28978, glue set 409.8197fil
+..\vbox(483.69687+0.0)x307.28978, glue set 409.81976fil
 ...\write-{}
 ...\glue(\topskip) 3.16669
-...\hbox(6.83331+1.94444)x307.28978, glue set 271.8730fil
+...\hbox(6.83331+1.94444)x307.28978, glue set 271.87305fil
 ....\hbox(0.0+0.0)x15.0
 ....\OT1/cmr/m/n/10 B
 ....\OT1/cmr/m/n/10 u
@@ -176,4 +176,3 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 0.0001fil
 ..\glue(\baselineskip) 30.0
 ..\hbox(0.0+0.0)x307.28978
-{/usr/local/texlive/2014/texmf-var/fonts/map/pdftex/updmap/pdftex.map}

--- a/testfiles/dgroup_width.tlg
+++ b/testfiles/dgroup_width.tlg
@@ -30,10 +30,10 @@ Completed box being shipped out [1]
 ...\hbox(0.0+0.0)x307.28978
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(483.69687+0.0)x307.28978, glue set 416.3746fil
+..\vbox(483.69687+0.0)x307.28978, glue set 416.37462fil
 ...\write-{}
 ...\glue(\topskip) 3.16669
-...\hbox(6.83331+1.94444)x307.28978, glue set 271.8730fil
+...\hbox(6.83331+1.94444)x307.28978, glue set 271.87305fil
 ....\hbox(0.0+0.0)x15.0
 ....\OT1/cmr/m/n/10 B
 ....\OT1/cmr/m/n/10 u
@@ -80,7 +80,7 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue -1.11111
 ...\glue(\baselineskip) 2.0
-...\hbox(7.5+2.5)x307.28978, glue set 288.9563fil
+...\hbox(7.5+2.5)x307.28978, glue set 288.95639fil
 ....\glue 0.0 plus 1.0fil
 ....\hbox(7.5+2.5)x18.33339
 .....\OT1/cmr/m/n/10 (
@@ -266,4 +266,3 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 0.0001fil
 ..\glue(\baselineskip) 30.0
 ..\hbox(0.0+0.0)x307.28978
-{/usr/local/texlive/2014/texmf-var/fonts/map/pdftex/updmap/pdftex.map}

--- a/testfiles/frame.tlg
+++ b/testfiles/frame.tlg
@@ -30,7 +30,7 @@ Completed box being shipped out [1]
 ...\hbox(0.0+0.0)x307.28978
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(483.69687+0.0)x300.48979, glue set 338.7777fil
+..\vbox(483.69687+0.0)x300.48979, glue set 338.77779fil
 ...\write-{}
 ...\glue(\topskip) 0.0
 ...\hbox(14.15291+9.11122)x300.48979, glue set 0.0
@@ -303,4 +303,3 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 0.0001fil
 ..\glue(\baselineskip) 30.0
 ..\hbox(0.0+0.0)x307.28978
-{/usr/local/texlive/2014/texmf-var/fonts/map/pdftex/updmap/pdftex.map}

--- a/testfiles/framesep.tlg
+++ b/testfiles/framesep.tlg
@@ -30,7 +30,7 @@ Completed box being shipped out [1]
 ...\hbox(0.0+0.0)x307.28978
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(483.69687+0.0)x317.87086, glue set 269.2872fil
+..\vbox(483.69687+0.0)x317.87086, glue set 269.28722fil
 ...\write-{}
 ...\glue(\topskip) 0.0
 ...\hbox(14.15291+9.11122)x300.48979, glue set 0.0
@@ -394,4 +394,3 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 0.0001fil
 ..\glue(\baselineskip) 30.0
 ..\hbox(0.0+0.0)x307.28978
-{/usr/local/texlive/2014/texmf-var/fonts/map/pdftex/updmap/pdftex.map}

--- a/testfiles/hiderel.tlg
+++ b/testfiles/hiderel.tlg
@@ -30,14 +30,14 @@ Completed box being shipped out [1]
 ...\hbox(0.0+0.0)x307.28978
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(483.69687+0.0)x307.28978, glue set 234.2830fil
+..\vbox(483.69687+0.0)x307.28978, glue set 234.28302fil
 ...\write-{}
 ...\glue(\topskip) 10.0
 ...\rule(0.0+0.0)x*
 ...\penalty 10000
 ...\glue 20.38887
 ...\glue(\baselineskip) 4.5
-...\hbox(7.5+2.5)x307.28978, glue set 294.5119fil
+...\hbox(7.5+2.5)x307.28978, glue set 294.51196fil
 ....\glue 0.0 plus 1.0fil
 ....\hbox(7.5+2.5)x12.77782
 .....\OT1/cmr/m/n/10 (
@@ -312,7 +312,7 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 13.38887
 ...\glue(\baselineskip) 2.55556
-...\hbox(7.5+2.5)x307.28978, glue set 294.5119fil
+...\hbox(7.5+2.5)x307.28978, glue set 294.51196fil
 ....\glue 0.0 plus 1.0fil
 ....\hbox(7.5+2.5)x12.77782
 .....\OT1/cmr/m/n/10 (
@@ -584,7 +584,7 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 13.38887
 ...\glue(\baselineskip) 2.55556
-...\hbox(7.5+2.5)x307.28978, glue set 294.5119fil
+...\hbox(7.5+2.5)x307.28978, glue set 294.51196fil
 ....\glue 0.0 plus 1.0fil
 ....\hbox(7.5+2.5)x12.77782
 .....\OT1/cmr/m/n/10 (
@@ -856,7 +856,7 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 6.44444
 ...\glue(\baselineskip) 2.55556
-...\hbox(7.5+2.5)x307.28978, glue set 294.5119fil
+...\hbox(7.5+2.5)x307.28978, glue set 294.51196fil
 ....\glue 0.0 plus 1.0fil
 ....\hbox(7.5+2.5)x12.77782
 .....\OT1/cmr/m/n/10 (
@@ -1120,4 +1120,3 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 0.0001fil
 ..\glue(\baselineskip) 30.0
 ..\hbox(0.0+0.0)x307.28978
-{/usr/local/texlive/2014/texmf-var/fonts/map/pdftex/updmap/pdftex.map}

--- a/testfiles/indentstep.tlg
+++ b/testfiles/indentstep.tlg
@@ -45,14 +45,14 @@ Completed box being shipped out [1]
 ...\hbox(0.0+0.0)x307.28978
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(483.69687+0.0)x307.28978, glue set 334.3278fil
+..\vbox(483.69687+0.0)x307.28978, glue set 334.32784fil
 ...\write-{}
 ...\glue(\topskip) 10.0
 ...\rule(0.0+0.0)x*
 ...\penalty 10000
 ...\glue 13.44444
 ...\glue(\baselineskip) 4.5
-...\hbox(7.5+2.5)x307.28978, glue set 294.5119fil
+...\hbox(7.5+2.5)x307.28978, glue set 294.51196fil
 ....\glue 0.0 plus 1.0fil
 ....\hbox(7.5+2.5)x12.77782
 .....\OT1/cmr/m/n/10 (
@@ -810,7 +810,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
 ...\glue(\baselineskip) 5.66667 plus 2.0
-...\hbox(7.5+2.5)x307.28978, glue set 294.5119fil
+...\hbox(7.5+2.5)x307.28978, glue set 294.51196fil
 ....\glue 0.0 plus 1.0fil
 ....\hbox(7.5+2.5)x12.77782
 .....\OT1/cmr/m/n/10 (
@@ -824,4 +824,3 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 0.0001fil
 ..\glue(\baselineskip) 30.0
 ..\hbox(0.0+0.0)x307.28978
-{/usr/local/texlive/2014/texmf-var/fonts/map/pdftex/updmap/pdftex.map}

--- a/testfiles/mathstyle-activechars.tlg
+++ b/testfiles/mathstyle-activechars.tlg
@@ -20,7 +20,7 @@ Author: wspr
 ! Missing $ inserted.
 <inserted text> 
 $
-l.13 Using ^ a
+l. ...Using ^ a
 nd _:
 I've inserted a begin-math/end-math symbol since I think
 you left one out. Proceed, with fingers crossed.
@@ -31,7 +31,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ! Missing $ inserted.
 <inserted text> 
 $
-l.14 
+l. ...
 I've inserted a begin-math/end-math symbol since I think
 you left one out. Proceed, with fingers crossed.
 Completed box being shipped out [1]
@@ -43,10 +43,10 @@ Completed box being shipped out [1]
 ...\hbox(0.0+0.0)x307.28978
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(483.69687+0.0)x307.28978, glue set 370.3221fil
+..\vbox(483.69687+0.0)x307.28978, glue set 370.32219fil
 ...\write-{}
 ...\glue(\topskip) 3.05556
-...\hbox(6.94444+1.94444)x307.28978, glue set 245.3698fil
+...\hbox(6.94444+1.94444)x307.28978, glue set 245.36986fil
 ....\hbox(0.0+0.0)x15.0
 ....\OT1/cmr/m/n/10 U
 ....\OT1/cmr/m/n/10 s
@@ -66,9 +66,9 @@ Completed box being shipped out [1]
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0 plus 1.0
-...\hbox(0.0+0.0)x307.28978, glue set 107.9140fil
+...\hbox(0.0+0.0)x307.28978, glue set 107.91405fil
 ....\hbox(0.0+0.0)x15.0
-....\hbox(0.0+0.0)x184.37573, glue set 92.1878fil
+....\hbox(0.0+0.0)x184.37573, glue set 92.18787fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\penalty 10000
@@ -156,7 +156,7 @@ Completed box being shipped out [1]
 ...\glue(\belowdisplayskip) 10.0 plus 2.0 minus 5.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\lineskip) 1.0
-...\hbox(6.94444+0.0)x307.28978, glue set 259.7341fil
+...\hbox(6.94444+0.0)x307.28978, glue set 259.73418fil
 ....\hbox(0.0+0.0)x15.0
 ....\OT1/cmr/m/n/10 N
 ....\OT1/cmr/m/n/10 e
@@ -207,4 +207,3 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 0.0001fil
 ..\glue(\baselineskip) 30.0
 ..\hbox(0.0+0.0)x307.28978
-{/usr/local/texlive/2014/texmf-var/fonts/map/pdftex/updmap/pdftex.map}

--- a/testfiles/mathstyle-default.tlg
+++ b/testfiles/mathstyle-default.tlg
@@ -33,7 +33,7 @@ Completed box being shipped out [1]
 ..\vbox(483.69687+0.0)x307.28978, glue set 384.3207fil
 ...\write-{}
 ...\glue(\topskip) 3.05556
-...\hbox(6.94444+1.94444)x307.28978, glue set 230.8452fil
+...\hbox(6.94444+1.94444)x307.28978, glue set 230.84521fil
 ....\hbox(0.0+0.0)x15.0
 ....\OT1/cmr/m/n/10 U
 ....\OT1/cmr/m/n/10 s
@@ -134,7 +134,7 @@ Completed box being shipped out [1]
 ...\glue(\belowdisplayshortskip) 6.0 plus 3.0 minus 3.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\lineskip) 1.0
-...\hbox(6.94444+0.0)x307.28978, glue set 259.7341fil
+...\hbox(6.94444+0.0)x307.28978, glue set 259.73418fil
 ....\hbox(0.0+0.0)x15.0
 ....\OT1/cmr/m/n/10 N
 ....\OT1/cmr/m/n/10 e
@@ -185,4 +185,3 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 0.0001fil
 ..\glue(\baselineskip) 30.0
 ..\hbox(0.0+0.0)x307.28978
-{/usr/local/texlive/2014/texmf-var/fonts/map/pdftex/updmap/pdftex.map}

--- a/testfiles/mathstyle-noactivechars.tlg
+++ b/testfiles/mathstyle-noactivechars.tlg
@@ -20,7 +20,7 @@ Author: wspr
 ! Missing $ inserted.
 <inserted text> 
 $
-l.13 Using ^
+l. ...Using ^
 and _:
 I've inserted a begin-math/end-math symbol since I think
 you left one out. Proceed, with fingers crossed.
@@ -31,7 +31,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ! Missing $ inserted.
 <inserted text> 
 $
-l.14 
+l. ...
 I've inserted a begin-math/end-math symbol since I think
 you left one out. Proceed, with fingers crossed.
 Completed box being shipped out [1]
@@ -43,10 +43,10 @@ Completed box being shipped out [1]
 ...\hbox(0.0+0.0)x307.28978
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(483.69687+0.0)x307.28978, glue set 370.3221fil
+..\vbox(483.69687+0.0)x307.28978, glue set 370.32219fil
 ...\write-{}
 ...\glue(\topskip) 3.05556
-...\hbox(6.94444+1.94444)x307.28978, glue set 245.3698fil
+...\hbox(6.94444+1.94444)x307.28978, glue set 245.36986fil
 ....\hbox(0.0+0.0)x15.0
 ....\OT1/cmr/m/n/10 U
 ....\OT1/cmr/m/n/10 s
@@ -66,9 +66,9 @@ Completed box being shipped out [1]
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0 plus 1.0
-...\hbox(0.0+0.0)x307.28978, glue set 107.9140fil
+...\hbox(0.0+0.0)x307.28978, glue set 107.91405fil
 ....\hbox(0.0+0.0)x15.0
-....\hbox(0.0+0.0)x184.37573, glue set 92.1878fil
+....\hbox(0.0+0.0)x184.37573, glue set 92.18787fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\penalty 10000
@@ -156,7 +156,7 @@ Completed box being shipped out [1]
 ...\glue(\belowdisplayskip) 10.0 plus 2.0 minus 5.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\lineskip) 1.0
-...\hbox(6.94444+0.0)x307.28978, glue set 259.7341fil
+...\hbox(6.94444+0.0)x307.28978, glue set 259.73418fil
 ....\hbox(0.0+0.0)x15.0
 ....\OT1/cmr/m/n/10 N
 ....\OT1/cmr/m/n/10 e
@@ -207,4 +207,3 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 0.0001fil
 ..\glue(\baselineskip) 30.0
 ..\hbox(0.0+0.0)x307.28978
-{/usr/local/texlive/2014/texmf-var/fonts/map/pdftex/updmap/pdftex.map}

--- a/testfiles/number.tlg
+++ b/testfiles/number.tlg
@@ -30,7 +30,7 @@ Completed box being shipped out [1]
 ...\hbox(0.0+0.0)x307.28978
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(483.69687+0.0)x307.28978, glue set 363.8656fil
+..\vbox(483.69687+0.0)x307.28978, glue set 363.86562fil
 ...\write-{}
 ...\glue(\topskip) 0.0
 ...\hbox(14.15291+9.11122)x307.28978, glue set 1.0
@@ -226,4 +226,3 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 0.0001fil
 ..\glue(\baselineskip) 30.0
 ..\hbox(0.0+0.0)x307.28978
-{/usr/local/texlive/2014/texmf-var/fonts/map/pdftex/updmap/pdftex.map}

--- a/testfiles/spread.tlg
+++ b/testfiles/spread.tlg
@@ -30,14 +30,14 @@ Completed box being shipped out [1]
 ...\hbox(0.0+0.0)x307.28978
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(483.69687+0.0)x307.28978, glue set 332.1930fil
+..\vbox(483.69687+0.0)x307.28978, glue set 332.19307fil
 ...\write-{}
 ...\glue(\topskip) 10.0
 ...\rule(0.0+0.0)x*
 ...\penalty 10000
 ...\glue 6.44444
 ...\glue(\baselineskip) 4.5
-...\hbox(7.5+2.5)x307.28978, glue set 294.5119fil
+...\hbox(7.5+2.5)x307.28978, glue set 294.51196fil
 ....\glue 0.0 plus 1.0fil
 ....\hbox(7.5+2.5)x12.77782
 .....\OT1/cmr/m/n/10 (
@@ -291,7 +291,7 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 12.13498
 ...\glue(\baselineskip) 2.55556
-...\hbox(7.5+2.5)x307.28978, glue set 294.5119fil
+...\hbox(7.5+2.5)x307.28978, glue set 294.51196fil
 ....\glue 0.0 plus 1.0fil
 ....\hbox(7.5+2.5)x12.77782
 .....\OT1/cmr/m/n/10 (
@@ -545,7 +545,7 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 3.59917
 ...\glue(\baselineskip) 2.55556
-...\hbox(7.5+2.5)x307.28978, glue set 294.5119fil
+...\hbox(7.5+2.5)x307.28978, glue set 294.51196fil
 ....\glue 0.0 plus 1.0fil
 ....\hbox(7.5+2.5)x12.77782
 .....\OT1/cmr/m/n/10 (
@@ -794,4 +794,3 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 0.0001fil
 ..\glue(\baselineskip) 30.0
 ..\hbox(0.0+0.0)x307.28978
-{/usr/local/texlive/2014/texmf-var/fonts/map/pdftex/updmap/pdftex.map}

--- a/testfiles/style.tlg
+++ b/testfiles/style.tlg
@@ -30,7 +30,7 @@ Completed box being shipped out [1]
 ...\hbox(0.0+0.0)x307.28978
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(483.69687+0.0)x307.28978, glue set 407.6667fil
+..\vbox(483.69687+0.0)x307.28978, glue set 407.66673fil
 ...\write-{}
 ...\glue(\topskip) 0.0
 ...\hbox(14.15291+9.11122)x307.28978, glue set 1.0
@@ -158,4 +158,3 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 0.0001fil
 ..\glue(\baselineskip) 30.0
 ..\hbox(0.0+0.0)x307.28978
-{/usr/local/texlive/2014/texmf-var/fonts/map/pdftex/updmap/pdftex.map}


### PR DESCRIPTION
As LuaTeX has a  `\mathstyle` primitive, the `mathstyle`/`breqn` should use it. This will also make it a bit easier for the LaTeX kernel to make the LuaTeX primitives available under their 'natural' names.