### PR TITLE
LuaTeX/\mathstyle update

### DIFF
--- a/mathstyle.dtx
+++ b/mathstyle.dtx
@@ -391,7 +391,7 @@ and the derived files
 % primitive. Very rarely used anyway.
 %    \begin{macrocode}
 \def\mathchoice{%
-  \relax\ifcase\mathstyle
+  \relax\ifcase\numexpr\mathstyle\relax
     \expandafter\@firstoffour % Display
   \or
     \expandafter\@firstoffour % Cramped display
@@ -453,7 +453,7 @@ and the derived files
 \begingroup\expandafter\expandafter\expandafter\endgroup
 \expandafter\ifx\csname directlua\endcsname\relax
   \def\fracstyle{%
-    \ifcase\mathstyle
+    \ifcase\numexpr\mathstyle\relax
       \chardef\mathstyle=\@ne
     \or
       \chardef\mathstyle=\@ne
@@ -474,7 +474,7 @@ and the derived files
 % and friends.
 %    \begin{macrocode}
 \def\currentmathstyle{%
-  \ifcase\mathstyle
+  \ifcase\numexpr\mathstyle\relax
     \@@displaystyle
   \or
     \@@displaystyle

--- a/mathstyle.dtx
+++ b/mathstyle.dtx
@@ -129,7 +129,7 @@ and the derived files
 %<package>\NeedsTeXFormat{LaTeX2e}
 %<package>\ProvidesPackage{mathstyle}
 %<*package|driver>
-  [2015/08/11 v0.98d Tracking mathstyle implicitly]
+  [2016/04/09 v0.98e Tracking mathstyle implicitly]
 %</package|driver>
 %<*driver>
 \documentclass{ltxdoc}

--- a/mathstyle.dtx
+++ b/mathstyle.dtx
@@ -4,7 +4,7 @@
 % Copyright (C) 2007-2008 by Morten Hoegholm
 % Copyright (C) 2007-2014 by Lars Madsen
 % Copyright (C) 2007-2014 by Will Robertson
-% Copyright (C) 2015 by Will Robertson, Joseph Wright
+% Copyright (C) 2015,2016 by Will Robertson, Joseph Wright
 %
 % This work may be distributed and/or modified under the
 % conditions of the LaTeX Project Public License, either
@@ -79,7 +79,7 @@ Copyright (C) 1997-2003 by Michael J. Downes
 Copyright (C) 2007-2011 by Morten Hoegholm et al
 Copyright (C) 2007-2014 by Lars Madsen
 Copyright (C) 2007-2014 by Will Robertson
-Copyright (C) 2015 by Will Robertson, Joseph Wright
+Copyright (C) 2015,2106 by Will Robertson, Joseph Wright
 
 This work may be distributed and/or modified under the
 conditions of the LaTeX Project Public License, either

--- a/mathstyle.dtx
+++ b/mathstyle.dtx
@@ -386,6 +386,8 @@ and the derived files
 %    \end{macrocode}
 %
 % \begin{macro}{\mathchoice}
+% \changes{v0.98e}{2016/04/09}{Lua\TeX{} primitive \cs{mathstyle} needs
+%   termination}
 % \cs{mathchoice} is now just a switch. Note that this redefinition
 % does not allow the arbitrary \meta{filler} of the \TeX\
 % primitive. Very rarely used anyway.
@@ -432,6 +434,8 @@ and the derived files
 %    \end{macrocode}
 % \changes{v0.90}{2011/08/03}{\cs{fracstyle} must be called \emph{after}
 %   changing to the required style}
+% \changes{v0.98e}{2016/04/09}{Lua\TeX{} primitive \cs{mathstyle} needs
+%   termination}
 % \end{macro}
 %
 %    \begin{macrocode}
@@ -447,6 +451,7 @@ and the derived files
 \renewcommand{\dbinom}{\genfrac\displaystyle(){0pt}}
 \renewcommand{\tbinom}{\genfrac\textstyle(){0pt}}
 %    \end{macrocode}
+
 % The \cs{fracstyle} command is a switch to go one level down but no
 % further than three.
 %    \begin{macrocode}
@@ -469,6 +474,8 @@ and the derived files
   \def\fracstyle{}
 \fi
 %    \end{macrocode}
+% \changes{v0.98e}{2016/04/09}{Lua\TeX{} primitive \cs{mathstyle} needs
+%   termination}
 % The \cs{currentmathstyle} checks the value of \cs{mathstyle} and
 % switches to it so it is in essence the opposite of \cs{displaystyle}
 % and friends.


### PR DESCRIPTION
It turns out the `\mathstyle` primitive expands to an integer in a macro-like not register-like way, so
termination is required.
